### PR TITLE
Remove helm template install

### DIFF
--- a/Dockerfile.2.K8S
+++ b/Dockerfile.2.K8S
@@ -22,7 +22,6 @@ ENV HELM_HOME=/home/tgf
 RUN curl -s -L https://kubernetes-helm.storage.googleapis.com/helm-v${HELM_VERSION}-linux-amd64.tar.gz | tar xzv && mv ./linux-amd64/helm ${EXE_FOLDER}/helm && \
     mkdir -p $(helm home)/plugins && rm -rf ./linux-amd64
 
-# Install helm-template
-RUN helm plugin install https://github.com/technosophos/helm-template && \
-    pip3 install deepdiff flatten_dict PyYAML && \
+# Install pip3 packages and make utils executable
+RUN pip3 install deepdiff flatten_dict PyYAML && \
     chmod +x $EXE_FOLDER/*


### PR DESCRIPTION
from https://github.com/technosophos/helm-template:
`If you are using a recent version of Helm, you do not need this anymore!`