### PR TITLE
Update versions

### DIFF
--- a/Dockerfile.0.Base
+++ b/Dockerfile.0.Base
@@ -4,7 +4,7 @@ ARG EXE_FOLDER=/usr/local/bin
 ARG EXT=_linux_64-bits.zip
 
 LABEL vendor="Coveo"
-LABEL maintainer "jgiroux@coveo.com"
+LABEL maintainer "tools@coveo.com"
 
 ENV TGF_IMAGE="coveo/tgf"
 ENV TGF_IMAGE_TAG="base"
@@ -19,14 +19,14 @@ RUN apk update && \
     adduser -D deploy
 
 # Update version here (do not move at the beginning of the file since it would slow down the docker build)
-ENV TERRAFORM_VERSION="0.11.12"
-ENV TERRAGRUNT_VERSION="1.3.2"
-ENV GOTEMPLATE_VERSION="2.7.5"
+ENV TERRAFORM_VERSION="0.11.13"
+ENV TERRAGRUNT_VERSION="1.3.4"
+ENV GOTEMPLATE_VERSION="2.7.6"
 RUN curl -sLo_ https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip && unzip -p _ > ${EXE_FOLDER}/terraform && \
     curl -sLo_ https://github.com/coveo/terragrunt/releases/download/v${TERRAGRUNT_VERSION}/terragrunt_${TERRAGRUNT_VERSION}${EXT} && unzip -p _ > ${EXE_FOLDER}/terragrunt && \
     curl -sLo_ https://github.com/coveo/gotemplate/releases/download/v${GOTEMPLATE_VERSION}/gotemplate_${GOTEMPLATE_VERSION}${EXT} && unzip -p _ > ${EXE_FOLDER}/gotemplate && \
     chmod +x $EXE_FOLDER/* && rm _
 
-ENV NEW_TERRAFORM_VERSION="0.12.0-beta1"
+ENV NEW_TERRAFORM_VERSION="0.12.0-beta2"
 RUN curl -sLo_ https://releases.hashicorp.com/terraform/${NEW_TERRAFORM_VERSION}/terraform_${NEW_TERRAFORM_VERSION}_linux_amd64.zip && unzip -p _ > ${EXE_FOLDER}/terraform_new && \
     chmod +x $EXE_FOLDER/* && rm _

--- a/Dockerfile.1
+++ b/Dockerfile.1
@@ -4,7 +4,7 @@ ARG EXE_FOLDER=/usr/local/bin
 ARG EXT=_linux_64-bits.zip
 
 LABEL vendor="Coveo"
-LABEL maintainer "jgiroux@coveo.com"
+LABEL maintainer "tools@coveo.com"
 
 ENV TGF_IMAGE_TAG=""
 
@@ -19,7 +19,7 @@ RUN apk add py2-pip python3 groff less tree && \
     apk add jq zip nano vim git mercurial
 
 # Update version here (do not move at the beginning of the file since it would slow down the docker build)
-ENV TF_LINT_VERSION="0.7.4"
+ENV TF_LINT_VERSION="0.7.5"
 ENV TF_DOC_VERSION="0.3.2"
 ENV TF_QUANTUM_VERSION="0.5.0"
 RUN curl -sLo_ https://github.com/wata727/tflint/releases/download/v${TF_LINT_VERSION}/tflint_linux_amd64.zip && unzip -p _ > ${EXE_FOLDER}/tflint && \

--- a/Dockerfile.2.AWS
+++ b/Dockerfile.2.AWS
@@ -4,11 +4,11 @@ ARG EXE_FOLDER=/usr/local/bin
 ARG EXT=_linux_64-bits.zip
 
 LABEL vendor="Coveo"
-LABEL maintainer "jgiroux@coveo.com"
+LABEL maintainer "tools@coveo.com"
 
 ENV TGF_IMAGE_TAG="aws"
 
 # Update version here (do not move at the beginning of the file since it would slow down the docker build)
-ENV TF_AWS_VERSION="1.60.0-coveo.0"
+ENV TF_AWS_VERSION="2.7.0-coveo.0"
 RUN curl -sLo_ https://github.com/coveo/terraform-provider-aws/releases/download/v${TF_AWS_VERSION}/terraform-provider-aws_${TF_AWS_VERSION}${EXT} && unzip -p _ > ${EXE_FOLDER}/terraform-provider-aws && \
     chmod +x $EXE_FOLDER/* && rm _

--- a/Dockerfile.2.K8S
+++ b/Dockerfile.2.K8S
@@ -3,7 +3,7 @@ FROM coveo/tgf:${TRAVIS_TAG}-aws
 ARG EXE_FOLDER=/usr/local/bin
 
 LABEL vendor="Coveo"
-LABEL maintainer "jgiroux@coveo.com"
+LABEL maintainer "tools@coveo.com"
 
 ENV TGF_IMAGE_TAG="k8s"
 
@@ -11,13 +11,13 @@ ENV TGF_IMAGE_TAG="k8s"
 RUN apk add openssh git
 
 # Install kubectl
-ENV KUBE_VERSION="1.13.4"
+ENV KUBE_VERSION="1.14.1"
 ENV KUBECONFIG=/home/tgf/.kube/config
 RUN curl -sLo_ https://storage.googleapis.com/kubernetes-release/release/v${KUBE_VERSION}/bin/linux/amd64/kubectl && mv _ ${EXE_FOLDER}/kubectl && \
     mkdir -p /home/tgf/.kube && touch ${KUBECONFIG} && chmod 666 ${KUBECONFIG}
 
 # Install helm (git is also required by helm)
-ENV HELM_VERSION="2.13.0"
+ENV HELM_VERSION="2.13.1"
 ENV HELM_HOME=/home/tgf
 RUN curl -s -L https://kubernetes-helm.storage.googleapis.com/helm-v${HELM_VERSION}-linux-amd64.tar.gz | tar xzv && mv ./linux-amd64/helm ${EXE_FOLDER}/helm && \
     mkdir -p $(helm home)/plugins && rm -rf ./linux-amd64

--- a/disabled - Dockerfile.3.Full
+++ b/disabled - Dockerfile.3.Full
@@ -1,7 +1,7 @@
 FROM ubuntu:latest
 
 LABEL vendor="Coveo"
-LABEL maintainer "jgiroux@coveo.com"
+LABEL maintainer "tools@coveo.com"
 
 ENV TGF_IMAGE="coveo/tgf"
 ENV TGF_IMAGE_TAG="full"


### PR DESCRIPTION
terraform 0.11.12 => 0.11.13
terragrunt 1.3.2 => 1.3.3
gotemplate 2.7.5 => 2.7.6
terraform12 0.12.0-beta1 => 0.12.0-beta2
tflint 0.7.4 => 0.7.5
terraform-provider-aws 1.60.0-coveo.0 => 2.7.0-coveo.0
kubectl 1.13.4 => 1.14.1
helm 2.13.0 => 2.13.1